### PR TITLE
Throw a more meaningful error when TOPPRA fails

### DIFF
--- a/airo_drake/__init__.py
+++ b/airo_drake/__init__.py
@@ -42,6 +42,7 @@ from airo_drake.collision.collision_checking import (
     filter_collisions_between_all_body_pairs,
     list_collisions_between_bodies,
 )
+from airo_drake.exceptions import TimeParameterizationError
 
 
 __all__ = [
@@ -75,4 +76,5 @@ __all__ = [
     "calculate_valid_joint_paths",
     "filter_collisions_between_all_body_pairs",
     "list_collisions_between_bodies",
+    "TimeParameterizationError",
 ]

--- a/airo_drake/exceptions.py
+++ b/airo_drake/exceptions.py
@@ -1,0 +1,2 @@
+class TimeParameterizationError(RuntimeError):
+    """Raised when a path could not be time parameterized."""

--- a/airo_drake/time_parametrization/toppra.py
+++ b/airo_drake/time_parametrization/toppra.py
@@ -20,6 +20,9 @@ def time_parametrize_toppra(
         joints: A joint path or trajectory.
         joint_speed_limit: The maximum joint speed in rad/s.
         joint_acceleration_limit: The maximum joint acceleration in rad/s^2.
+
+    Raises:
+        TimeParameterizationError: The path could not be time parameterized.
     """
     if isinstance(joints, Trajectory):
         joint_trajectory = joints

--- a/airo_drake/time_parametrization/toppra.py
+++ b/airo_drake/time_parametrization/toppra.py
@@ -4,6 +4,8 @@ from pydrake.multibody.optimization import CalcGridPointsOptions, Toppra
 from pydrake.multibody.plant import MultibodyPlant
 from pydrake.trajectories import PathParameterizedTrajectory, PiecewisePolynomial, Trajectory
 
+from airo_drake.exceptions import TimeParameterizationError
+
 
 def time_parametrize_toppra(
     plant: MultibodyPlant,
@@ -41,7 +43,7 @@ def time_parametrize_toppra(
     time_parametrization = toppra.SolvePathParameterization()
 
     if time_parametrization is None:
-        raise ValueError("TOPP-RA failed to find a valid time parametrization.")
+        raise TimeParameterizationError("TOPP-RA failed to find a valid time parametrization.")
 
     joint_trajectory = PathParameterizedTrajectory(joint_trajectory, time_parametrization)
 


### PR DESCRIPTION
When wanting to change control flow when time_parameterize_toppra fails, we need to catch ValueErrors, but these can also come from different parts of the code base. To make catching the right error easier, I've defined a custom error type, such that downstream code can use

```
try:
    # ...
except TimeParameterizationError:
    # ...
```

to catch only that specific error.

## Note

- Perhaps there are other exceptions too that we want to handle in this way.
- I still need to update the docstring of the function.