### PR TITLE
Fix NumPy version to < 2.0

### DIFF
--- a/environment.yaml
+++ b/environment.yaml
@@ -11,7 +11,7 @@ dependencies:
   - python=3.10
   - pip
   - pip:
-    - numpy
+    - numpy=1.26.4
     - pytest
     - pre-commit
     - mypy

--- a/environment.yaml
+++ b/environment.yaml
@@ -11,7 +11,7 @@ dependencies:
   - python=3.10
   - pip
   - pip:
-    - numpy=1.26.4
+    - numpy==1.26.4
     - pytest
     - pre-commit
     - mypy


### PR DESCRIPTION
NumPy 2.0 is not backwards compatible and causes issues with PyTest